### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require": {
         "laravel-enso/core": "^8.0",
-        "laravel-enso/enums": "^2.0",
+        "laravel-enso/enums": "^2.2",
         "laravel-enso/helpers": "^2.0",
         "laravel-enso/migrator": "^2.0",
         "laravel-enso/select": "^4.0",


### PR DESCRIPTION
- laravel-enso/activity-log 4.2.0 requires laravel-enso/enums ^2.0 -> satisfiable by laravel-enso/enums[2.0.0, ..., 2.2.0].
- laravel-enso/enums[2.0.0, ..., 2.0.2] require laravel/framework ^7.0 -> found laravel/framework[v7.0.0, ..., 7.x-dev] but it conflicts with your root composer.json require (^9.2).